### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "type": "git",
     "url": "https://github.com/simatec/ioBroker.schoolfree"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "axios": "^1.5.0",
     "@iobroker/adapter-core": "^3.0.3"


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 due to npm7 not installing peer dependencies. So this adapter requires node 16